### PR TITLE
feat: Add granular invalidation control to SvelteKit adapter

### DIFF
--- a/packages/nuqs-svelte/src/lib/adapters/svelte-kit/adapter.svelte
+++ b/packages/nuqs-svelte/src/lib/adapters/svelte-kit/adapter.svelte
@@ -9,9 +9,19 @@
 
   type Props = {
     children?: Snippet;
+
+    /**
+     * A function that determines whether a navigation should trigger
+     * a full invalidation of all `load` functions.
+     *
+     * - `'deps'` (default): Relies on SvelteKit's built-in dependency tracking.
+     * - `'always'`: Always invalidates all load functions.
+     * - `(url: URL) => boolean`: A custom predicate function.
+     */
+    invalidation?: "deps" | "always" | ((url: URL) => boolean);
   };
 
-  let { children }: Props = $props();
+  let { children, invalidation = "deps" }: Props = $props();
 
   const adapter: AdapterInterface = {
     updateUrl: (search, options) => {
@@ -29,10 +39,17 @@
             keepFocus: true,
           });
         } else {
+          let shouldInvalidate = false;
+          if (invalidation === "always") {
+            shouldInvalidate = true;
+          } else if (typeof invalidation === "function") {
+            shouldInvalidate = invalidation(url);
+          }
+
           goto(url, {
             replaceState: history === "replace",
             keepFocus: true,
-            invalidateAll: true,
+            invalidateAll: shouldInvalidate,
           });
         }
 


### PR DESCRIPTION
Fixes #21
Addresses feedback from #12

This PR introduces a new `invalidation` prop to the SvelteKit `<NuqsAdapter>` component, giving developers fine-grained control over how `load` functions are re-run during non-shallow URL updates.

#### Problem

The previous approach of always using `invalidateAll: true` for non-shallow updates was too aggressive and could lead to unnecessary data fetching and performance degradation in pages with nested layouts, as pointed out in issue #12.

#### Solution

The new `invalidation` prop offers three strategies:

* **`'deps'` (default):** Relies on SvelteKit's default, performant dependency-tracking mechanism. `load` functions will only re-run if their specific dependencies (like a value from `url.searchParams`) have changed.
* **`'always'`:** Ensures all `load` functions are re-run by calling `goto` with `{ invalidateAll: true }`. This is useful for guaranteeing data freshness when dependency tracking may not be sufficient.
* **`(url: URL) => boolean`:** A custom predicate function that returns `true` if a full invalidation should occur for the given URL, offering maximum flexibility.

This change defaults to the most performant strategy while providing a clear opt-in for developers who require guaranteed refetching.

**Example Usage:**

```svelte
<script lang="ts">
  import { NuqsAdapter } from 'nuqs-svelte/adapters/svelte-kit';
  let { children } = $props();
</script>

<NuqsAdapter invalidation="always">
  {@render children()}
</NuqsAdapter>
```